### PR TITLE
fix: add displayName to components to fix ESLint warning

### DIFF
--- a/templates/components/ui/input.tsx
+++ b/templates/components/ui/input.tsx
@@ -294,6 +294,8 @@ export const Input = forwardRef<TextInput, InputProps>(
   }
 );
 
+Input.displayName = 'Input';
+
 export interface GroupedInputProps {
   children: React.ReactNode;
   containerStyle?: ViewStyle;
@@ -605,3 +607,5 @@ export const GroupedInputItem = forwardRef<TextInput, GroupedInputItemProps>(
     return renderItemContent();
   }
 );
+
+GroupedInputItem.displayName = 'GroupedInputItem';


### PR DESCRIPTION
Added displayName to the Input and GroupedInputItem components to fix the ESLint warning about missing component names.