### PR TITLE
fix: Broken init step

### DIFF
--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -56,7 +56,7 @@ import { themeRegistry } from './theme/index.js';
 import { hooksRegistry } from './hooks/index.js';
 import { inputRegistry } from './input.js';
 import { chartsRegistry } from './charts/index.js';
-import { alertDialogRegistry } from './alert-dialog';
+import { alertDialogRegistry } from './alert-dialog.js';
 import { avoidKeyboardRegistry } from './avoid-keyboard.js';
 
 export const REGISTRY: Record<string, ComponentRegistry> = {


### PR DESCRIPTION
# Summary

Fixes the error encountered when trying to run the `bna-ui init` step by adding the .js extenstion to the recently added alert-dialog component.

```
❌ Failed to start CLI: Cannot find module '/Users/ibrahim/.npm/_npx/fe4fc0723348de04/node_modules/bna-ui/dist/registry/alert-dialog' imported from /Users/ibrahim/.npm/_npx/fe4fc0723348de04/node_modules/bna-ui/dist/registry/index.js
```