### PR TITLE
hotfix: update `useColor` usages

### DIFF
--- a/templates/components/ui/button.tsx
+++ b/templates/components/ui/button.tsx
@@ -71,7 +71,7 @@ export const Button = forwardRef<View, ButtonProps>(
     const secondaryColor = useColor('secondary');
     const secondaryForegroundColor = useColor('secondaryForeground');
     const destructiveColor = useColor('red');
-    const destructiveForegroundColor = useColor({}, 'destructiveForeground');
+    const destructiveForegroundColor = useColor('destructiveForeground');
     const greenColor = useColor('green');
     const borderColor = useColor('border');
 

--- a/templates/components/ui/icon.tsx
+++ b/templates/components/ui/icon.tsx
@@ -17,7 +17,7 @@ export function Icon({
   strokeWidth = 1.8,
   ...rest
 }: Props) {
-  const themedColor = useColor({ light: lightColor, dark: darkColor }, 'icon');
+  const themedColor = useColor('icon', { light: lightColor, dark: darkColor });
 
   // Use provided color prop if available, otherwise use themed color
   const iconColor = color || themedColor;

--- a/templates/components/ui/text.tsx
+++ b/templates/components/ui/text.tsx
@@ -27,7 +27,7 @@ export const Text = forwardRef<RNText, TextProps>(
     { variant = 'body', lightColor, darkColor, style, children, ...props },
     ref
   ) => {
-    const textColor = useColor({ light: lightColor, dark: darkColor }, 'text');
+    const textColor = useColor('text', { light: lightColor, dark: darkColor });
     const mutedColor = useColor('textMuted');
 
     const getTextStyle = (): TextStyle => {

--- a/templates/demo/popover/popover-menu.tsx
+++ b/templates/demo/popover/popover-menu.tsx
@@ -24,7 +24,7 @@ function MenuItem({
   onPress,
   destructive = false,
 }: MenuItemProps) {
-  const textColor = useColor({}, destructive ? 'destructive' : 'foreground');
+  const textColor = useColor(destructive ? 'destructive' : 'foreground');
   const mutedColor = useColor('muted');
 
   return (

--- a/templates/start-convex/components/ui/button.tsx
+++ b/templates/start-convex/components/ui/button.tsx
@@ -71,7 +71,7 @@ export const Button = forwardRef<View, ButtonProps>(
     const secondaryColor = useColor('secondary');
     const secondaryForegroundColor = useColor('secondaryForeground');
     const destructiveColor = useColor('red');
-    const destructiveForegroundColor = useColor({}, 'destructiveForeground');
+    const destructiveForegroundColor = useColor('destructiveForeground');
     const greenColor = useColor('green');
     const borderColor = useColor('border');
 

--- a/templates/start-convex/components/ui/icon.tsx
+++ b/templates/start-convex/components/ui/icon.tsx
@@ -17,7 +17,7 @@ export function Icon({
   strokeWidth = 1.8,
   ...rest
 }: Props) {
-  const themedColor = useColor({ light: lightColor, dark: darkColor }, 'icon');
+  const themedColor = useColor('icon', { light: lightColor, dark: darkColor });
 
   // Use provided color prop if available, otherwise use themed color
   const iconColor = color || themedColor;

--- a/templates/start-convex/components/ui/text.tsx
+++ b/templates/start-convex/components/ui/text.tsx
@@ -27,7 +27,7 @@ export const Text = forwardRef<RNText, TextProps>(
     { variant = 'body', lightColor, darkColor, style, children, ...props },
     ref
   ) => {
-    const textColor = useColor({ light: lightColor, dark: darkColor }, 'text');
+    const textColor = useColor('text', { light: lightColor, dark: darkColor });
     const mutedColor = useColor('textMuted');
 
     const getTextStyle = (): TextStyle => {

--- a/templates/start/components/ui/button.tsx
+++ b/templates/start/components/ui/button.tsx
@@ -71,7 +71,7 @@ export const Button = forwardRef<View, ButtonProps>(
     const secondaryColor = useColor('secondary');
     const secondaryForegroundColor = useColor('secondaryForeground');
     const destructiveColor = useColor('red');
-    const destructiveForegroundColor = useColor({}, 'destructiveForeground');
+    const destructiveForegroundColor = useColor('destructiveForeground');
     const greenColor = useColor('green');
     const borderColor = useColor('border');
 

--- a/templates/start/components/ui/icon.tsx
+++ b/templates/start/components/ui/icon.tsx
@@ -17,7 +17,7 @@ export function Icon({
   strokeWidth = 1.8,
   ...rest
 }: Props) {
-  const themedColor = useColor({ light: lightColor, dark: darkColor }, 'icon');
+  const themedColor = useColor('icon', { light: lightColor, dark: darkColor });
 
   // Use provided color prop if available, otherwise use themed color
   const iconColor = color || themedColor;

--- a/templates/start/components/ui/text.tsx
+++ b/templates/start/components/ui/text.tsx
@@ -27,7 +27,7 @@ export const Text = forwardRef<RNText, TextProps>(
     { variant = 'body', lightColor, darkColor, style, children, ...props },
     ref
   ) => {
-    const textColor = useColor({ light: lightColor, dark: darkColor }, 'text');
+    const textColor = useColor('text', { light: lightColor, dark: darkColor });
     const mutedColor = useColor('textMuted');
 
     const getTextStyle = (): TextStyle => {


### PR DESCRIPTION
Although `useColor` was updated to have fewer required args, its usage remains the same. 
(Also mentioned in #23 )

This problem should be fixed immediately since new developers will struggle to use this library out of the box. 
Also, I believe we should avoid breaking changes like this and instead should've created a new hook.

Again, thank you for maintaining this library! 