### PR TITLE
style: improved camera permission placemet

### DIFF
--- a/templates/components/ui/camera.tsx
+++ b/templates/components/ui/camera.tsx
@@ -403,7 +403,7 @@ export const Camera = forwardRef<CameraRef, CameraProps>(
 
     if (!permission.granted) {
       return (
-        <View style={{flex: 1,justifyContent: "center",alignItems: "center",paddingHorizontal: 8,}}>
+        <View style={[styles.container, { paddingHorizontal: 8 }]}>
           <View
             style={[styles.permissionContainer, { backgroundColor: cardColor }]}
           >

--- a/templates/components/ui/camera.tsx
+++ b/templates/components/ui/camera.tsx
@@ -403,24 +403,26 @@ export const Camera = forwardRef<CameraRef, CameraProps>(
 
     if (!permission.granted) {
       return (
-        <View
-          style={[styles.permissionContainer, { backgroundColor: cardColor }]}
-        >
-          <CameraIcon
-            size={36}
-            color={textColor}
-            style={styles.permissionIcon}
-          />
-          <Text variant='title' style={{ textAlign: 'center' }}>
-            Camera Access Required
-          </Text>
-          <Text variant='body' style={{ textAlign: 'center' }}>
-            We need access to your camera to take pictures and videos
-          </Text>
-          <View style={{ width: '100%' }}>
-            <Button onPress={requestPermission} style={{ width: '100%' }}>
-              Grant Permission
-            </Button>
+        <View style={{flex: 1,justifyContent: "center",alignItems: "center",paddingHorizontal: 8,}}>
+          <View
+            style={[styles.permissionContainer, { backgroundColor: cardColor }]}
+          >
+            <CameraIcon
+              size={36}
+              color={textColor}
+              style={styles.permissionIcon}
+            />
+            <Text variant='title' style={{ textAlign: 'center' }}>
+              Camera Access Required
+            </Text>
+            <Text variant='body' style={{ textAlign: 'center' }}>
+              We need access to your camera to take pictures and videos
+            </Text>
+            <View style={{ width: '100%' }}>
+              <Button onPress={requestPermission} style={{ width: '100%' }}>
+                Grant Permission
+              </Button>
+            </View>
           </View>
         </View>
       );


### PR DESCRIPTION
## Type of Change: 
Styling Improvement

## Changes made:

This PR fixes the layout and vertical alignment of the Camera Permission screen when camera access is asked.

Previously, the permission card was not properly centered on the screen and appeared misaligned vertically. The issue was caused by the permission container not being wrapped in a full-screen flex container with proper centering styles.

## Changes made:

Wrapped the permission UI inside a full-screen container:

<View style={{
    flex: 1,
    justifyContent: "center",
    alignItems: "center",
    paddingHorizontal: 8,
  }}>
  
##  Testing made: 

- [x] Tested on IOS
- [x] Tested on Android
  
## Screenshots:

## Before
<p >
  <img src="https://github.com/user-attachments/assets/00a3434b-8d3f-418f-a2f3-919b8738407d" width="200" />
</p>

## After
### IOS
<p >
  <img src="https://github.com/user-attachments/assets/fdfd932c-04f3-45ca-b1a3-dcb301f1957f" width="200" />
</p>

### Android

<p >
  <img src="https://github.com/user-attachments/assets/0e4fd7e7-fb55-45bb-a831-d5aebf630e2c" width="200" />
</p>

## Checklist:

- [x] Self-review completed
- [x] No breaking changes 

